### PR TITLE
Rename intro page, minor edits.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@ layout: default
         <span>Home</span>
         <ul>
           <li>
-            <a href="{{site.baseurl}}/what's-in-the-box/">What's in the box</a>
+            <a href="{{site.baseurl}}/overview/">Overview</a>
           </li>
           <li>
             <a href="{{site.baseurl}}/browser-support/">Browser support</a>

--- a/browser-support.md
+++ b/browser-support.md
@@ -16,7 +16,7 @@ title: Browser support
 
 At the time of writing, Chrome 60, Safari 11.1, and iOS 11.3 natively support all of these features, out of the box. To run `pwa-starter-kit` on other browsers, you need to use a combination of polyfills and transpilation (e.g. babel).
 
-This step is automated by the `npm run build` script for you, but in case you want to roll your own building and bundling strategy, here is an overview of what is needed and where:
+This step is automated for you by the `npm run build` script, but in case you want to roll your own building and bundling strategy, here is an overview of what is needed and where:
 
 Feature  | Action needed | On what browsers|
  ------------ | :-----------: | -----------: |

--- a/overview.md
+++ b/overview.md
@@ -1,25 +1,27 @@
 ---
 layout: post
-title: What's in the box?
+title: "Overview: What's in the box?"
 ---
-The `pwa-starter-kit` is a sample app that's meant to be used as a starting point for building PWAs. Out of the box, it gives you the following features:
-- all the PWA goodness (manifest, service worker)
-- a responsive layout
-- application theming
-- example of using Redux for state management
-- offline UI
-- simple routing solution
-- fast time-to-interactive and first-paint through the PRPL pattern
-- easy deployment to prpl-server or static hosting
-- unit and integrating testing starting points
-- documentation about other advanced patterns
+The `pwa-starter-kit` is a set of templates you can use as a starting point for building PWAs. Out of the box, the default template gives you the following features:
+
+- All the PWA goodness (manifest, service worker).
+- A responsive layout.
+- Application theming.
+- Example of using Redux for state management.
+- Offline UI.
+- Simple routing solution.
+- Fast time-to-interactive and first-paint using the PRPL pattern.
+- Easy deployment to prpl-server or static hosting.
+- Unit and integration testing starting points.
+- Documentation about other advanced patterns.
 
 ## Other templates
-If you already know what you're doing and want a simpler template to start from, we've created several separate templates, with some of the features removed:
+
+If you already know what you're doing and want a different template to start from, we've created several separate templates, with different sets of features:
 
 ### `template-typescript` ([code](https://github.com/Polymer/pwa-starter-kit/tree/template-typescript), [demo](https://pwa-starter-kit.appspot.com/))
 
-This template is the same as the `master` template and it's using `TypeScript`.
+This template is the same as the `master` template, but implemented using `TypeScript`.
 
 ### `template-minimal-ui` ([code](https://github.com/Polymer/pwa-starter-kit/tree/template-minimal-ui), [demo](https://template-minimal-ui-dot-pwa-starter-kit.appspot.com/))
 
@@ -34,11 +36,12 @@ This template has the same UI elements as the `master` one (`app-layout` element
 This template is very similar to the `master` template, in the sense that it keeps both Redux for state management, and all of the UI elements. The main difference is that the wide screen layout displays a persistent `app-drawer`, inline with the content.
 
 ## `pwa-helpers`
-A lot of the reusable functionality of `pwa-starter-kit` has already been pulled out as helper methods, into a separate repo. The [`pwa-helpers`](https://github.com/Polymer/pwa-helpers) contains:
-- `router.js`: a very basic router that calls a callback any time the location changes
-- `network.js`: calls a callback whenever the network connectivity of the app changes
-- `metadata.js`: utility method that sets the Twitter card/open graph metadata for a specific page
-- `media-query.js`: calls a callback whenever a media-query matches in response to the viewport size changing
-- `connect-mixin.js`: small mixin that you can add to a Custom Element base class to automatically connect to a Redux store
+A lot of the reusable functionality of `pwa-starter-kit` has already been pulled out as helper methods, into a separate repo. The [`pwa-helpers`](https://github.com/Polymer/pwa-helpers) repo contains:
+
+- `router.js`: A very basic router that calls a callback any time the location changes.
+- `network.js`: Calls a callback whenever the network connectivity of the app changes.
+- `metadata.js`: Utility method that sets the Twitter card/open graph metadata for a specific page.
+- `media-query.js`: Calls a callback whenever a media-query matches in response to the viewport size changing.
+- `connect-mixin.js`: Small mixin that you can add to a Custom Element base class to automatically connect to a Redux store.
 
 Each of these helpers is very small, and can be implemented in many different, bespoke ways. However, they each represent a feature that is often needed across many different applications, so unless you already have a solution planned for your app, you could use one of these.

--- a/setup.md
+++ b/setup.md
@@ -9,8 +9,9 @@ The app uses [Web Components](https://www.webcomponents.org/introduction), [lit-
 
 This app depends on several [npm](https://www.npmjs.com/) packages, which you must be able to install. Make sure that you've already installed [node.js](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) before moving on to the next step. If you already have `node` installed, make sure you're using the latest version -- we recommend using `v8.0.0` and above.
 
-## Creating a new app
-To create a new app that uses the `pwa-starter-kit` template:
+## Create a new app
+
+To create a new app that uses the default `pwa-starter-kit` template:
 ```
 git clone --depth 1 https://github.com/Polymer/pwa-starter-kit my-app
 cd my-app
@@ -35,6 +36,21 @@ my-app
 ├── ... (misc project config files)
 ```
 Checkout the [folder structure]({{site.baseurl}}/configuring-and-personalizing#folder-structure) page for details on what each file is used for.
+
+
+## Alternate templates
+
+To create a new app based on one of the other templates listed in [Other templates]({{site.baseurl}}/overview#other-templates), you can clone the appropriate branch from the `pwa-starter-kit` repo:
+
+```
+git clone --depth 1 -b <template-name> --single-branch https://github.com/Polymer/pwa-starter-kit my-app
+```
+
+For example, to start from Typescript template (`template-typescript`):
+
+```
+git clone --depth 1 -b template-typescript --single-branch https://github.com/Polymer/pwa-starter-kit my-app
+```
 
 ### Installing dependencies
 To install the project's dependencies, run


### PR DESCRIPTION
Intro page wasn't showing up on app engine--I think it didn't like the quote in the slug.

These changes are staged to https://pwa-starter-kit.polymer-project.org/